### PR TITLE
Update CMakeLists.txt (Some API require at least C++17 to run)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 project(my_app LANGUAGES C CXX)
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 
 # Step 1: Add hello_imgui as a subdirectory
 add_subdirectory(external/hello_imgui)


### PR DESCRIPTION
# Some API require at least C++17 to run
## before fix:
```
"optional": is not a member of "std" 😭
```
![image](https://github.com/pthom/hello_imgui_my_app/assets/112557849/ad1a41f9-5404-4bb8-9cf3-3f88538aeee0)


## after fix:
### build ok😁
![image](https://github.com/pthom/hello_imgui_my_app/assets/112557849/01bbdb28-36b2-43a4-9cb3-406a3490f771)

